### PR TITLE
feat(index): serializable cache for Bitmap and LabelList scalar indices

### DIFF
--- a/rust/lance-core/src/utils/mask.rs
+++ b/rust/lance-core/src/utils/mask.rs
@@ -13,6 +13,7 @@ use deepsize::DeepSizeOf;
 use itertools::Itertools;
 use roaring::{MultiOps, RoaringBitmap, RoaringTreemap};
 
+use crate::cache::CacheCodecImpl;
 use crate::{Error, Result};
 
 use super::address::RowAddress;
@@ -658,6 +659,16 @@ impl RowAddrTreeMap {
                     (fragment << 32) | row_offset
                 }),
             })
+    }
+}
+
+impl CacheCodecImpl for RowAddrTreeMap {
+    fn serialize(&self, writer: &mut dyn Write) -> Result<()> {
+        self.serialize_into(writer)
+    }
+
+    fn deserialize(data: &bytes::Bytes) -> Result<Self> {
+        Self::deserialize_from(data.as_ref())
     }
 }
 

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -19,10 +19,14 @@ use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion_common::ScalarValue;
 use deepsize::DeepSizeOf;
 use futures::{StreamExt, TryStreamExt, stream};
+use lance_arrow::ipc::{
+    read_ipc_stream_single_at, read_len_prefixed_bytes_at, write_ipc_stream,
+    write_len_prefixed_bytes,
+};
 use lance_core::utils::mask::RowSetOps;
 use lance_core::{
     Error, ROW_ID, Result,
-    cache::{CacheKey, LanceCache, WeakLanceCache},
+    cache::{CacheCodec, CacheCodecImpl, CacheKey, LanceCache, WeakLanceCache},
     error::LanceOptionExt,
     utils::{
         mask::{NullableRowAddrSet, RowAddrTreeMap},
@@ -144,6 +148,151 @@ impl CacheKey for BitmapKey {
 
     fn type_name() -> &'static str {
         "Bitmap"
+    }
+
+    fn codec() -> Option<CacheCodec> {
+        Some(CacheCodec::from_impl::<RowAddrTreeMap>())
+    }
+}
+
+/// The serializable state of a [`BitmapIndex`].
+///
+/// `BitmapIndex` holds non-serializable infrastructure (an `IndexStore`, a
+/// cache handle, a lazy reader, a fragment-reuse index). `BitmapIndexState`
+/// captures just the data needed to rebuild it: the value→file-offset map,
+/// the null bitmap, and the value type.
+#[derive(Debug, Clone)]
+pub struct BitmapIndexState {
+    /// Value-to-row-offset lookup, encoded as an Arrow `RecordBatch` so we can
+    /// reuse the existing IPC utilities for zero-copy round trips.
+    ///
+    /// Schema: `keys: <value_type>`, `offsets: UInt64`. Iteration order of
+    /// `index_map` is preserved on serialize and the `BTreeMap` resorts the
+    /// entries on deserialize, so the wire form does not need to be sorted.
+    lookup_batch: RecordBatch,
+    /// Already-remapped null bitmap (remapping is applied during load, so the
+    /// cached state matches the in-memory representation).
+    null_map: Arc<RowAddrTreeMap>,
+    /// Cached separately from the schema for the empty-index case where the
+    /// `lookup_batch` is empty but we still need to remember the column type.
+    value_type: DataType,
+}
+
+impl DeepSizeOf for BitmapIndexState {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.lookup_batch.get_array_memory_size() + self.null_map.deep_size_of_children(context)
+    }
+}
+
+impl BitmapIndexState {
+    pub(crate) fn from_index(index: &BitmapIndex) -> Result<Self> {
+        Ok(Self {
+            lookup_batch: build_lookup_batch(&index.index_map, &index.value_type)?,
+            null_map: index.null_map.clone(),
+            value_type: index.value_type.clone(),
+        })
+    }
+
+    pub(crate) fn into_bitmap_index(
+        self,
+        store: Arc<dyn IndexStore>,
+        index_cache: &LanceCache,
+        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    ) -> Result<Arc<BitmapIndex>> {
+        let index_map = parse_lookup_batch(&self.lookup_batch)?;
+        Ok(Arc::new(BitmapIndex::new(
+            index_map,
+            self.null_map,
+            self.value_type,
+            store,
+            WeakLanceCache::from(index_cache),
+            frag_reuse_index,
+        )))
+    }
+}
+
+fn build_lookup_batch(
+    index_map: &BTreeMap<OrderableScalarValue, usize>,
+    value_type: &DataType,
+) -> Result<RecordBatch> {
+    let keys = if index_map.is_empty() {
+        arrow_array::new_empty_array(value_type)
+    } else {
+        ScalarValue::iter_to_array(index_map.keys().map(|k| k.0.clone()))?
+    };
+    let offsets = Arc::new(UInt64Array::from_iter_values(
+        index_map.values().map(|v| *v as u64),
+    ));
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("keys", value_type.clone(), true),
+        Field::new("offsets", DataType::UInt64, false),
+    ]));
+    Ok(RecordBatch::try_new(schema, vec![keys, offsets])?)
+}
+
+fn parse_lookup_batch(batch: &RecordBatch) -> Result<BTreeMap<OrderableScalarValue, usize>> {
+    let keys = batch.column(0);
+    let offsets = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .ok_or_else(|| {
+            Error::internal("BitmapIndexState: expected UInt64 offsets column".to_string())
+        })?;
+    let mut index_map = BTreeMap::new();
+    for idx in 0..batch.num_rows() {
+        let value = OrderableScalarValue(ScalarValue::try_from_array(keys, idx)?);
+        index_map.insert(value, offsets.value(idx) as usize);
+    }
+    Ok(index_map)
+}
+
+impl CacheCodecImpl for BitmapIndexState {
+    /// Wire format:
+    /// ```text
+    /// [u64 null_map_len][null_map bytes]
+    /// [arrow IPC stream: (keys: <value_type>, offsets: UInt64)]
+    /// ```
+    /// The value type is recovered from the IPC stream schema.
+    fn serialize(&self, writer: &mut dyn std::io::Write) -> Result<()> {
+        let mut null_bytes = Vec::with_capacity(self.null_map.serialized_size());
+        self.null_map.serialize_into(&mut null_bytes)?;
+        write_len_prefixed_bytes(writer, &null_bytes)?;
+        write_ipc_stream(&self.lookup_batch, writer)?;
+        Ok(())
+    }
+
+    fn deserialize(data: &bytes::Bytes) -> Result<Self> {
+        let mut offset = 0;
+        let null_bytes = read_len_prefixed_bytes_at(data, &mut offset)?;
+        let null_map = Arc::new(RowAddrTreeMap::deserialize_from(null_bytes.as_ref())?);
+        let lookup_batch = read_ipc_stream_single_at(data, &mut offset)?;
+        let value_type = lookup_batch.schema().field(0).data_type().clone();
+        Ok(Self {
+            lookup_batch,
+            null_map,
+            value_type,
+        })
+    }
+}
+
+/// Cache key for a [`BitmapIndexState`]. The cache is already namespaced
+/// per-index by the caller, so a constant key suffices.
+struct BitmapIndexStateKey;
+
+impl CacheKey for BitmapIndexStateKey {
+    type ValueType = BitmapIndexState;
+
+    fn key(&self) -> std::borrow::Cow<'_, str> {
+        "state".into()
+    }
+
+    fn type_name() -> &'static str {
+        "BitmapIndexState"
+    }
+
+    fn codec() -> Option<CacheCodec> {
+        Some(CacheCodec::from_impl::<BitmapIndexState>())
     }
 }
 
@@ -1542,6 +1691,34 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
         Ok(BitmapIndex::load(index_store, frag_reuse_index, cache).await? as Arc<dyn ScalarIndex>)
     }
 
+    async fn get_from_cache(
+        &self,
+        index_store: Arc<dyn IndexStore>,
+        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        cache: &LanceCache,
+    ) -> Result<Option<Arc<dyn ScalarIndex>>> {
+        let Some(state) = cache.get_with_key(&BitmapIndexStateKey).await else {
+            return Ok(None);
+        };
+        let state = (*state).clone();
+        let index = state.into_bitmap_index(index_store, cache, frag_reuse_index)?;
+        Ok(Some(index as Arc<dyn ScalarIndex>))
+    }
+
+    async fn put_in_cache(&self, cache: &LanceCache, index: Arc<dyn ScalarIndex>) -> Result<()> {
+        let bitmap = index
+            .as_any()
+            .downcast_ref::<BitmapIndex>()
+            .ok_or_else(|| {
+                Error::internal("BitmapIndexPlugin::put_in_cache called with a non-bitmap index")
+            })?;
+        let state = BitmapIndexState::from_index(bitmap)?;
+        cache
+            .insert_with_key(&BitmapIndexStateKey, Arc::new(state))
+            .await;
+        Ok(())
+    }
+
     async fn load_statistics(
         &self,
         index_store: Arc<dyn IndexStore>,
@@ -1588,6 +1765,41 @@ mod tests {
     use lance_core::utils::{address::RowAddress, tempfile::TempObjDir};
     use lance_io::object_store::ObjectStore;
     use std::collections::HashMap;
+
+    fn assert_state_roundtrips(state: &BitmapIndexState) {
+        let mut buf = Vec::new();
+        state.serialize(&mut buf).unwrap();
+        let restored = BitmapIndexState::deserialize(&bytes::Bytes::from(buf)).unwrap();
+        assert_eq!(restored.lookup_batch, state.lookup_batch);
+        assert_eq!(&*restored.null_map, &*state.null_map);
+        assert_eq!(restored.value_type, state.value_type);
+    }
+
+    #[test]
+    fn test_bitmap_index_state_codec_roundtrip() {
+        // Non-empty state with a few keys and a populated null map.
+        let mut index_map = BTreeMap::new();
+        index_map.insert(OrderableScalarValue(ScalarValue::Int32(Some(1))), 0);
+        index_map.insert(OrderableScalarValue(ScalarValue::Int32(Some(7))), 1);
+        index_map.insert(OrderableScalarValue(ScalarValue::Int32(Some(42))), 2);
+        let mut null_map = RowAddrTreeMap::new();
+        null_map.insert(RowAddress::new_from_parts(0, 3).into());
+        null_map.insert(RowAddress::new_from_parts(0, 5).into());
+        let state = BitmapIndexState {
+            lookup_batch: build_lookup_batch(&index_map, &DataType::Int32).unwrap(),
+            null_map: Arc::new(null_map),
+            value_type: DataType::Int32,
+        };
+        assert_state_roundtrips(&state);
+
+        // Empty state: no keys, empty null map. Schema still carries the type.
+        let empty_state = BitmapIndexState {
+            lookup_batch: build_lookup_batch(&BTreeMap::new(), &DataType::Utf8).unwrap(),
+            null_map: Arc::new(RowAddrTreeMap::new()),
+            value_type: DataType::Utf8,
+        };
+        assert_state_roundtrips(&empty_state);
+    }
 
     #[tokio::test]
     async fn test_bitmap_lazy_loading_and_cache() {

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -19,7 +19,8 @@ use datafusion::physical_plan::{SendableRecordBatchStream, stream::RecordBatchSt
 use datafusion_common::ScalarValue;
 use deepsize::DeepSizeOf;
 use futures::{StreamExt, TryStream, TryStreamExt, stream::BoxStream};
-use lance_core::cache::LanceCache;
+use lance_arrow::ipc::{read_len_prefixed_bytes_at, write_len_prefixed_bytes};
+use lance_core::cache::{CacheCodec, CacheCodecImpl, CacheKey, LanceCache};
 use lance_core::error::LanceOptionExt;
 use lance_core::utils::mask::{NullableRowAddrSet, RowAddrTreeMap, RowSetOps};
 use lance_core::{Error, ROW_ID, Result};
@@ -31,7 +32,7 @@ use super::{BuiltinIndexType, SargableQuery, ScalarIndexParams};
 use super::{MetricsCollector, SearchResult};
 use crate::frag_reuse::FragReuseIndex;
 use crate::pbold;
-use crate::scalar::bitmap::BitmapIndexPlugin;
+use crate::scalar::bitmap::{BitmapIndexPlugin, BitmapIndexState};
 use crate::scalar::expression::{LabelListQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
     DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
@@ -488,6 +489,93 @@ async fn write_label_list_bitmap_index(
     .await
 }
 
+/// The serializable state of a [`LabelListIndex`].
+///
+/// `LabelListIndex` is a thin wrapper around a [`BitmapIndex`] plus a separate
+/// row bitmap tracking which list values were `NULL` (lost by unnest at build
+/// time). Its cache state is the corresponding [`BitmapIndexState`] plus the
+/// already-loaded `list_nulls`.
+#[derive(Debug, Clone)]
+pub struct LabelListIndexState {
+    bitmap_state: BitmapIndexState,
+    list_nulls: Arc<RowAddrTreeMap>,
+}
+
+impl DeepSizeOf for LabelListIndexState {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.bitmap_state.deep_size_of_children(context)
+            + self.list_nulls.deep_size_of_children(context)
+    }
+}
+
+impl LabelListIndexState {
+    fn from_index(index: &LabelListIndex) -> Result<Self> {
+        Ok(Self {
+            bitmap_state: BitmapIndexState::from_index(&index.values_index)?,
+            list_nulls: index.list_nulls.clone(),
+        })
+    }
+
+    fn into_label_list_index(
+        self,
+        store: Arc<dyn IndexStore>,
+        index_cache: &LanceCache,
+        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    ) -> Result<Arc<LabelListIndex>> {
+        let bitmap = self
+            .bitmap_state
+            .into_bitmap_index(store, index_cache, frag_reuse_index)?;
+        Ok(Arc::new(LabelListIndex::new(bitmap, self.list_nulls)))
+    }
+}
+
+impl CacheCodecImpl for LabelListIndexState {
+    /// Wire format:
+    /// ```text
+    /// [u64 list_nulls_len][list_nulls bytes]
+    /// [bitmap state bytes (self-delimiting)]
+    /// ```
+    fn serialize(&self, writer: &mut dyn std::io::Write) -> Result<()> {
+        let mut nulls_bytes = Vec::with_capacity(self.list_nulls.serialized_size());
+        self.list_nulls.serialize_into(&mut nulls_bytes)?;
+        write_len_prefixed_bytes(writer, &nulls_bytes)?;
+        self.bitmap_state.serialize(writer)?;
+        Ok(())
+    }
+
+    fn deserialize(data: &bytes::Bytes) -> Result<Self> {
+        let mut offset = 0;
+        let nulls_bytes = read_len_prefixed_bytes_at(data, &mut offset)?;
+        let list_nulls = Arc::new(RowAddrTreeMap::deserialize_from(nulls_bytes.as_ref())?);
+        // The bitmap state is self-delimiting (length-prefixed null map +
+        // Arrow IPC stream with EOS marker), so we can hand the remaining
+        // tail to it directly.
+        let bitmap_state = BitmapIndexState::deserialize(&data.slice(offset..))?;
+        Ok(Self {
+            bitmap_state,
+            list_nulls,
+        })
+    }
+}
+
+struct LabelListIndexStateKey;
+
+impl CacheKey for LabelListIndexStateKey {
+    type ValueType = LabelListIndexState;
+
+    fn key(&self) -> std::borrow::Cow<'_, str> {
+        "state".into()
+    }
+
+    fn type_name() -> &'static str {
+        "LabelListIndexState"
+    }
+
+    fn codec() -> Option<CacheCodec> {
+        Some(CacheCodec::from_impl::<LabelListIndexState>())
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct LabelListIndexPlugin;
 
@@ -605,5 +693,35 @@ impl ScalarIndexPlugin for LabelListIndexPlugin {
             LabelListIndex::load(index_store, frag_reuse_index, cache).await?
                 as Arc<dyn ScalarIndex>,
         )
+    }
+
+    async fn get_from_cache(
+        &self,
+        index_store: Arc<dyn IndexStore>,
+        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        cache: &LanceCache,
+    ) -> Result<Option<Arc<dyn ScalarIndex>>> {
+        let Some(state) = cache.get_with_key(&LabelListIndexStateKey).await else {
+            return Ok(None);
+        };
+        let state = (*state).clone();
+        let index = state.into_label_list_index(index_store, cache, frag_reuse_index)?;
+        Ok(Some(index as Arc<dyn ScalarIndex>))
+    }
+
+    async fn put_in_cache(&self, cache: &LanceCache, index: Arc<dyn ScalarIndex>) -> Result<()> {
+        let label_list = index
+            .as_any()
+            .downcast_ref::<LabelListIndex>()
+            .ok_or_else(|| {
+                Error::internal(
+                    "LabelListIndexPlugin::put_in_cache called with a non-label-list index",
+                )
+            })?;
+        let state = LabelListIndexState::from_index(label_list)?;
+        cache
+            .insert_with_key(&LabelListIndexStateKey, Arc::new(state))
+            .await;
+        Ok(())
     }
 }

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -2297,6 +2297,199 @@ async fn test_btree_prewarm_with_serializing_backend_serves_query_with_no_io() {
     );
 }
 
+/// Bitmap analogue of `test_btree_prewarm_with_serializing_backend_serves_query_with_no_io`:
+/// after prewarming a Bitmap scalar index through a serializing cache backend,
+/// an indexed-filter query serves results without any further IO. The
+/// serializing backend forces every cache hit through the `BitmapIndexState`
+/// (top-level state) and `RowAddrTreeMap` (per-value bitmap) `CacheCodec`
+/// impls, so this exercises both round-trip paths.
+#[tokio::test]
+async fn test_bitmap_prewarm_with_serializing_backend_serves_query_with_no_io() {
+    use lance_io::assert_io_eq;
+
+    use fts_serializing_backend::SerializingBackend;
+
+    let tmpdir = TempStrDir::default();
+    let uri = tmpdir.to_owned();
+    drop(tmpdir);
+
+    // Low-cardinality column so the index has several per-value bitmaps to
+    // round-trip through the per-key codec.
+    let num_rows: i32 = 8_000;
+    let values = Int32Array::from_iter_values((0..num_rows).map(|i| i % 16));
+    let ids = UInt64Array::from_iter_values(0..num_rows as u64);
+    let batch = RecordBatch::try_new(
+        arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("value", DataType::Int32, false),
+            arrow_schema::Field::new("id", DataType::UInt64, false),
+        ])
+        .into(),
+        vec![Arc::new(values) as ArrayRef, Arc::new(ids) as ArrayRef],
+    )
+    .unwrap();
+    let schema = batch.schema();
+    let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
+    let mut dataset = Dataset::write(batches, &uri, None).await.unwrap();
+    dataset
+        .create_index(
+            &["value"],
+            IndexType::Bitmap,
+            Some("value_idx".to_owned()),
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+
+    let backend = Arc::new(SerializingBackend::new());
+    let session = Arc::new(Session::with_index_cache_backend(
+        backend.clone(),
+        128 * 1024 * 1024,
+        Arc::new(lance_io::object_store::ObjectStoreRegistry::default()),
+    ));
+    let dataset = DatasetBuilder::from_uri(&uri)
+        .with_session(session)
+        .load()
+        .await
+        .unwrap();
+
+    dataset.object_store.as_ref().io_stats_incremental();
+    dataset.prewarm_index("value_idx").await.unwrap();
+
+    let serialized_after_prewarm = backend.serialized_entry_count().await;
+    assert!(
+        serialized_after_prewarm > 0,
+        "prewarm should have routed the bitmap state and per-value bitmaps through \
+         CacheCodec, but the serializing store was empty"
+    );
+
+    dataset.object_store.as_ref().io_stats_incremental();
+    let result = dataset
+        .scan()
+        .project(&[ROW_ID])
+        .unwrap()
+        .filter("value = 7")
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    let expected = (num_rows as usize) / 16;
+    assert_eq!(
+        result.num_rows(),
+        expected,
+        "indexed bitmap filter should return correct results after deserialization"
+    );
+
+    let stats = dataset.object_store.as_ref().io_stats_incremental();
+    assert_io_eq!(
+        stats,
+        read_iops,
+        0,
+        "Bitmap filter query should not perform IO after prewarm; the serializing \
+         cache backend must serve the index state and every per-value bitmap from memory"
+    );
+}
+
+/// LabelList analogue: after prewarming, an `array_has_any` query against a
+/// `LabelList` index serves results without any further IO. Exercises the
+/// `LabelListIndexState` codec (which embeds the inner bitmap state and the
+/// list-nulls bitmap) plus the same per-value bitmap codec.
+#[tokio::test]
+async fn test_label_list_prewarm_with_serializing_backend_serves_query_with_no_io() {
+    use lance_io::assert_io_eq;
+
+    use fts_serializing_backend::SerializingBackend;
+
+    let tmpdir = TempStrDir::default();
+    let uri = tmpdir.to_owned();
+    drop(tmpdir);
+
+    use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount};
+
+    let mut dataset = gen_batch()
+        .col(
+            "labels",
+            lance_datagen::array::rand_list_any(
+                lance_datagen::array::cycle::<arrow::datatypes::Int64Type>(vec![1, 2, 3, 4, 5]),
+                false,
+            ),
+        )
+        .into_dataset(&uri, FragmentCount::from(2), FragmentRowCount::from(2000))
+        .await
+        .unwrap();
+    dataset
+        .create_index(
+            &["labels"],
+            IndexType::LabelList,
+            Some("labels_idx".to_owned()),
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+    let expected = dataset
+        .scan()
+        .project(&[ROW_ID])
+        .unwrap()
+        .filter("array_has_any(labels, [3])")
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap()
+        .num_rows();
+    assert!(
+        expected > 0,
+        "test dataset must contain at least one row whose labels include 3"
+    );
+
+    let backend = Arc::new(SerializingBackend::new());
+    let session = Arc::new(Session::with_index_cache_backend(
+        backend.clone(),
+        128 * 1024 * 1024,
+        Arc::new(lance_io::object_store::ObjectStoreRegistry::default()),
+    ));
+    let dataset = DatasetBuilder::from_uri(&uri)
+        .with_session(session)
+        .load()
+        .await
+        .unwrap();
+
+    dataset.object_store.as_ref().io_stats_incremental();
+    dataset.prewarm_index("labels_idx").await.unwrap();
+
+    let serialized_after_prewarm = backend.serialized_entry_count().await;
+    assert!(
+        serialized_after_prewarm > 0,
+        "prewarm should have routed the label-list state and per-value bitmaps through \
+         CacheCodec, but the serializing store was empty"
+    );
+
+    dataset.object_store.as_ref().io_stats_incremental();
+    let result = dataset
+        .scan()
+        .project(&[ROW_ID])
+        .unwrap()
+        .filter("array_has_any(labels, [3])")
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(
+        result.num_rows(),
+        expected,
+        "indexed label-list filter should return correct results after deserialization"
+    );
+
+    let stats = dataset.object_store.as_ref().io_stats_incremental();
+    assert_io_eq!(
+        stats,
+        read_iops,
+        0,
+        "LabelList filter query should not perform IO after prewarm; the serializing \
+         cache backend must serve the index state and every per-value bitmap from memory"
+    );
+}
+
 #[tokio::test]
 async fn test_fts_phrase_query_with_removed_stop_words() {
     let tmpdir = TempStrDir::default();

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -389,10 +389,6 @@ pub async fn open_scalar_index(
     let index_details = fetch_index_details(dataset, column, index).await?;
     let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_details(index_details.as_ref())?;
 
-    if index_details.type_url.ends_with("LabelListIndexDetails") {
-        validate_label_list_index_compatibility(dataset, column, index, &index_store).await?;
-    }
-
     let frag_reuse_index = dataset.open_frag_reuse_index(metrics).await?;
 
     let index_cache = dataset
@@ -403,7 +399,14 @@ pub async fn open_scalar_index(
         .get_from_cache(index_store.clone(), frag_reuse_index.clone(), &index_cache)
         .await?
     {
+        // Compatibility check is only needed on first load; a cache hit means
+        // the index was already validated when it was originally opened in
+        // this session, so we can skip the extra `open_index_file` IOP.
         return Ok(index);
+    }
+
+    if index_details.type_url.ends_with("LabelListIndexDetails") {
+        validate_label_list_index_compatibility(dataset, column, index, &index_store).await?;
     }
 
     let index = plugin


### PR DESCRIPTION
Adds `CacheCodec` impls so Bitmap and LabelList index cache entries survive through a persistent cache backend, mirroring the BTree work in #6793.

- `CacheCodecImpl for RowAddrTreeMap` (delegates to existing `serialize_into`/`deserialize_from`), so per-value bitmap entries cached under `BitmapKey` are codec-backed.
- `BitmapIndexState` captures the value→offset map (Arrow IPC), the null bitmap, and the value type. `BitmapIndexPlugin` overrides `get_from_cache`/`put_in_cache` to store this sized state.
- `LabelListIndexState` wraps an inner `BitmapIndexState` plus `list_nulls` and gets the same plugin-level codec treatment.
- `open_scalar_index` skips the LabelList compatibility check on cache hits, so a fully-cached LabelList query no longer pays an extra `bitmap_page_lookup.lance` open per call.

## Tests

- Unit codec round-trip for `BitmapIndexState` (empty + populated).
- Integration tests `test_{bitmap,label_list}_prewarm_with_serializing_backend_serves_query_with_no_io` asserting zero IOPS after prewarm through a serializing cache backend.

Based on #6793; review that first.

Closes #6744